### PR TITLE
fix(): Add `pod_name` label to slicegw_latency metrics

### DIFF
--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -29,8 +29,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-//create latency metrics which has to be populated when we receive latency from tunnel
+// create latency metrics which has to be populated when we receive latency from tunnel
 var (
+	podName         = os.Getenv("HOSTNAME")
 	sourceClusterId = os.Getenv("CLUSTER_ID")
 	remoteClusterId = os.Getenv("REMOTE_CLUSTER_ID")
 	remoteGatewayId = os.Getenv("REMOTE_GATEWAY_ID")
@@ -38,6 +39,7 @@ var (
 	sliceName       = os.Getenv("SLICE_NAME")
 	namespace       = "kubeslice_system"
 	constlabels     = prometheus.Labels{
+		"pod_name":                podName,
 		"slice_name":              sliceName,
 		"source_slice_cluster_id": sourceClusterId,
 		"remote_slice_cluster_id": remoteClusterId,
@@ -50,7 +52,7 @@ var (
 	log            *logger.Logger = logger.NewLogger()
 )
 
-//common method get gauge metrics alongwith labels
+// common method get gauge metrics alongwith labels
 func getGaugeMetrics(name string, help string) prometheus.Gauge {
 	return prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -61,7 +63,7 @@ func getGaugeMetrics(name string, help string) prometheus.Gauge {
 		})
 }
 
-//method to register metrics to prometheus
+// method to register metrics to prometheus
 func StartMetricsCollector(metricCollectorPort string) {
 	metricCollectorPort = ":" + metricCollectorPort
 	log.Infof("Starting metric collector @ %s", metricCollectorPort)
@@ -86,7 +88,7 @@ func StartMetricsCollector(metricCollectorPort string) {
 	log.Info("Started Prometheus server at", metricCollectorPort)
 }
 
-//send http request
+// send http request
 func newHandlerWithHistogram(handler http.Handler, histogram *prometheus.HistogramVec) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()

--- a/pkg/sidecar/sidecarpb/gw_sidecar.pb.go
+++ b/pkg/sidecar/sidecarpb/gw_sidecar.pb.go
@@ -128,7 +128,6 @@ func (TcType) EnumDescriptor() ([]byte, []int) {
 	return file_pkg_sidecar_sidecarpb_gw_sidecar_proto_rawDescGZIP(), []int{1}
 }
 
-//
 type ClassType int32
 
 const (

--- a/pkg/sidecar/sidecarpb/gw_sidecar_utils.go
+++ b/pkg/sidecar/sidecarpb/gw_sidecar_utils.go
@@ -67,16 +67,16 @@ func getGwPodStatus() (*GwPodStatus, error) {
 	if statusMonitor != nil {
 		// Get the monitor status checks
 		checks := statusMonitor.Checks()
-		log.Info("checks","checks",checks)
+		log.Info("checks", "checks", checks)
 		for _, v := range checks {
 			stats, err := v.Status()
-			log.Info("stats","stats ",stats)
+			log.Info("stats", "stats ", stats)
 			if err != nil {
 				// this means that tunnel is not established
 				tunnelStatus.Status = TunnelStatusType_GW_TUNNEL_STATE_DOWN
 				podStatus.TunnelStatus = &tunnelStatus
 				log.Infof("pod status : %v", podStatus)
-				return podStatus,nil
+				return podStatus, nil
 			}
 			tunnelStatus = TunnelInterfaceStatus{
 				NetInterface: stats.NetInterface,


### PR DESCRIPTION
Issue: 
Different Prometheus versions are displaying different values for pod label for example for version 19.2.2, we get a label called `pod` and for `19.6` we got `kubernates_pod_name`

Fix:
Add a custom label to the slicegw metrics which will be consistent