### PR TITLE
fix(): Added tunnel pkt loss custom metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,6 +23,12 @@ func RecordLatencyMetric(latency float64) {
 	LatencyMetrics.Set(latency)
 }
 
+// Records packet loss for this sidecar
+func RecordPktLossMetric(latency float64) {
+	// Set Pkt Loss Gauge in prometheus
+	LatencyMetrics.Set(latency)
+}
+
 // Records rx bytes for this sidecar
 func RecordRxRateMetric(rxRate float64) {
 	// Set Rx bytes in prometheus

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -47,8 +47,9 @@ var (
 		"remote_gateway_id":       remoteGatewayId,
 	}
 	LatencyMetrics                = getGaugeMetrics("slicegw_latency", "latency Metrics From Slice Gateway")
-	RxRateMetrics                 = getGaugeMetrics("rx_rate", "Rx rate from Slice Gateway.")
-	TxRateMetrics                 = getGaugeMetrics("tx_rate", "Tx rate from Slice Gateway.")
+	PktLossMetrics                = getGaugeMetrics("slicegw_pkt_loss", "pkt loss Metrics From Slice Gateway")
+	RxRateMetrics                 = getGaugeMetrics("slicegw_rx_rate", "Rx rate from Slice Gateway.")
+	TxRateMetrics                 = getGaugeMetrics("slicegw_tx_rate", "Tx rate from Slice Gateway.")
 	log            *logger.Logger = logger.NewLogger()
 )
 
@@ -76,6 +77,7 @@ func StartMetricsCollector(metricCollectorPort string) {
 	prometheus.Register(histogramVec)
 
 	prometheus.MustRegister(LatencyMetrics)
+	prometheus.MustRegister(PktLossMetrics)
 	prometheus.MustRegister(RxRateMetrics)
 	prometheus.MustRegister(TxRateMetrics)
 

--- a/pkg/status/tunnel.go
+++ b/pkg/status/tunnel.go
@@ -89,6 +89,7 @@ func (t *TunnelChecker) Execute(interface{}) (err error) {
 	}
 	//add metrics which can be shown on prometheus
 	metrics.RecordLatencyMetric(float64(t.tunStatus.Latency))
+	metrics.RecordPktLossMetric(float64(t.tunStatus.PacketLoss))
 	metrics.RecordRxRateMetric(float64(t.tunStatus.RxRate))
 	metrics.RecordTxRateMetric(float64(t.tunStatus.TxRate))
 
@@ -228,7 +229,8 @@ func (t *TunnelChecker) updateNetworkStatus(ifaceName string) error {
 	t.log.Debugf("Command: %v output :%v", rxCmd, cmdOut)
 
 	curTime := getCurTimeMs()
-	timeDelta := (curTime - t.startTime) * 1000
+	// Get time delta in seconds
+	timeDelta := (curTime - t.startTime) / 1000
 	t.log.Debugf("Current time: %v Start Time : %v timeDelta: %v prev txBytes: %v prev rxBytes: %v cur txBytes: %v cur rxBytes: %v", curTime, t.startTime, timeDelta, t.txBytes, t.rxBytes, txBytes, rxBytes)
 	if (txBytes - t.txBytes) < 0 {
 		t.log.Errorf("Negative txBytes ")


### PR DESCRIPTION
Added a custom metric to record packet loss percentage for the gw tunnel between clusters. This would be useful in detecting if the tunnel was down or congested at any point of time. 