### PR TITLE
fix(): Delay setting the tunnel state to Down

### DIFF
--- a/pkg/sidecar/sidecarpb/gw_sidecar_utils.go
+++ b/pkg/sidecar/sidecarpb/gw_sidecar_utils.go
@@ -88,7 +88,9 @@ func getGwPodStatus() (*GwPodStatus, error) {
 				PacketLoss:   stats.PacketLoss,
 				Status:       TunnelStatusType_GW_TUNNEL_STATE_UP,
 			}
-			if tunnelStatus.PacketLoss > 80 || tunnelStatus.NetInterface == "" {
+			// Set the state of the tunnel to down only if there are contiguous instances (recorded by the
+			// stats.TotalPktLossIter counter) of total and complete, i.e 100%, pkt loss.
+			if stats.PacketLoss == 100 && stats.TotalPktLossIter >= status.GUARANTEED_PKTLOSS_COUNT {
 				tunnelStatus.Status = TunnelStatusType_GW_TUNNEL_STATE_DOWN
 			}
 

--- a/pkg/status/config.go
+++ b/pkg/status/config.go
@@ -36,13 +36,25 @@ type Config struct {
 
 // TunnelInterfaceStatus represents Tunnel Interface Status
 type TunnelInterfaceStatus struct {
-	NetInterface string `json:"netInterface,omitempty"`
-	LocalIP      string `json:"localIp,omitempty"`
-	PeerIP       string `json:"peerIp,omitempty"`
-	Latency      uint64 `json:"latency,omitempty"`
-	TxRate       uint64 `json:"txRate,omitempty"`
-	RxRate       uint64 `json:"rxRate,omitempty"`
-	PacketLoss   uint64 `json:"packetLoss,omitempty"`
-	Status       uint64 `json:"status,omitempty"`
+	NetInterface     string `json:"netInterface,omitempty"`
+	LocalIP          string `json:"localIp,omitempty"`
+	PeerIP           string `json:"peerIp,omitempty"`
+	Latency          uint64 `json:"latency,omitempty"`
+	TxRate           uint64 `json:"txRate,omitempty"`
+	RxRate           uint64 `json:"rxRate,omitempty"`
+	PacketLoss       uint64 `json:"packetLoss,omitempty"`
+	Status           uint64 `json:"status,omitempty"`
+	TotalPktLossIter uint32 `json: "totalPktLossIter,omitempty"`
 	sync.Mutex
 }
+
+var (
+	// This var holds the total number of contiguous 100% pkt loss events.
+	// When the number of total and complete pkt loss hits the GUARANTEED_PKTLOSS_COUNT,
+	// it would be safe to assume that the tunnel is down.
+	GUARANTEED_PKTLOSS_COUNT uint32 = 20
+	// We have a circular counter to keep track of total and complete pktloss on the tunnel.
+	// Once the count hits MAX_PKTLOSS_COUNT and if the tunnel is still down, the counter
+	// restarts from GUARANTEED_PKTLOSS_COUNT.
+	MAX_PKTLOSS_COUNT uint32 = 600
+)


### PR DESCRIPTION
We should not set tunnel state to down immediately after the first ping test failure. Added code to set the state to down after atleast 60 seconds of total pkt loss.