### PR TITLE
feat: Add topology type field for flexible routing support

### DIFF
--- a/pkg/sidecar/sidecarpb/gw_sidecar.go
+++ b/pkg/sidecar/sidecarpb/gw_sidecar.go
@@ -121,17 +121,22 @@ func (s *GwSidecar) UpdateConnectionContext(ctx context.Context, conContext *Sli
 		SliceGwRemoteClusterNodePort = conContext.GetRemoteSliceGwNodePort()
 	}
 
-	// Add Gateway Route as follows
-	// route add -net  <remote-subnet> netmask <255.255.255.0> gw <remove-vpn-ip>
+	// Add route to remote gateway's NSM subnet via VPN tunnel
 	_, dstIPNet, err := net.ParseCIDR(conContext.GetRemoteSliceGwNsmSubnet())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Error in Parsing CIDR")
 	}
+	
 	gwIP := net.ParseIP(conContext.GetRemoteSliceGwVpnIP())
-
 	route := netlink.Route{Dst: dstIPNet, Gw: gwIP}
-	log.Infof("RouteAdd args %v, %v ", dstIPNet, gwIP)
-
+	
+	topologyType := conContext.GetTopologyType()
+	if topologyType == "" {
+		topologyType = "full-mesh"
+	}
+	
+	log.Infof("Adding route for topology %s: %v via %v", topologyType, dstIPNet, gwIP)
+	
 	if err := netlink.RouteAdd(&route); err != nil {
 		log.Errorf("Gateway Pod RouteAdd Failed : %v", err)
 	}

--- a/pkg/sidecar/sidecarpb/gw_sidecar.pb.go
+++ b/pkg/sidecar/sidecarpb/gw_sidecar.pb.go
@@ -725,6 +725,8 @@ type SliceGwConnectionContext struct {
 	RemoteSliceGwNodeIP string `protobuf:"bytes,12,opt,name=remoteSliceGwNodeIP,proto3" json:"remoteSliceGwNodeIP,omitempty"`
 	// Remote slice gateway Node Port
 	RemoteSliceGwNodePort string `protobuf:"bytes,13,opt,name=remoteSliceGwNodePort,proto3" json:"remoteSliceGwNodePort,omitempty"`
+	// Topology type - full-mesh, custom, or restricted (for logging/metrics only)
+	TopologyType string `protobuf:"bytes,20,opt,name=topologyType,proto3" json:"topologyType,omitempty"`
 }
 
 func (x *SliceGwConnectionContext) Reset() {
@@ -846,6 +848,13 @@ func (x *SliceGwConnectionContext) GetRemoteSliceGwNodeIP() string {
 func (x *SliceGwConnectionContext) GetRemoteSliceGwNodePort() string {
 	if x != nil {
 		return x.RemoteSliceGwNodePort
+	}
+	return ""
+}
+
+func (x *SliceGwConnectionContext) GetTopologyType() string {
+	if x != nil {
+		return x.TopologyType
 	}
 	return ""
 }

--- a/pkg/sidecar/sidecarpb/gw_sidecar.proto
+++ b/pkg/sidecar/sidecarpb/gw_sidecar.proto
@@ -144,11 +144,11 @@ message SliceGwConnectionContext {
     string remoteSliceGwNsmSubnet = 11;
     // Remote slice gateway Node IP
     string remoteSliceGwNodeIP = 12;
-    // Remote slice gateway Node Port
-    string remoteSliceGwNodePort = 13;
-}
-
-service GwSidecarService {
+	// Remote slice gateway Node Port
+	string remoteSliceGwNodePort = 13;
+	// Topology type (for logging/metrics)
+	string topologyType = 20;
+}service GwSidecarService {
     // The Interface to get the Pod status.
     rpc GetStatus(google.protobuf.Empty) returns (GwPodStatus) {}
     // The Interface to get the Remote Gw Pod Name.


### PR DESCRIPTION
- Add topologyType field to SliceGwConnectionContext proto message
- Update route installation to log topology type
- Simplify route logic: always add direct routes (controller filters topology)
- Support full-mesh, custom, and restricted topologies