### PR TITLE
fix: make spoke gateway route slice traffic through the tunnel reliably

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ FROM alpine:3.21
 # tc - is needed for traffic control and shaping on the sidecar.  it is part of the iproute2
 
 RUN apk add --no-cache ca-certificates \
-    iproute2
+    iproute2 \
+    iptables
 
 # Copy our static executable.
 

--- a/pkg/sidecar/sidecarpb/gw_sidecar.go
+++ b/pkg/sidecar/sidecarpb/gw_sidecar.go
@@ -154,9 +154,36 @@ func (s *GwSidecar) UpdateConnectionContext(ctx context.Context, conContext *Sli
 			log.Errorf("VPP Gateway RouteAdd Failed : %v", err)
 		}
 	}
+	// Clamp the TCP MSS of connections crossing the tunnel to the path MTU. The
+	// pod-side NSM interface is MTU 1500 while the OpenVPN tunnel (tun0) is smaller,
+	// so full-size segments would otherwise be silently dropped (no "fragmentation
+	// needed" ICMP -> PMTU black hole) and TCP would stall. Required for
+	// spoke-to-spoke traffic (which crosses two tunnels), and also fixes plain
+	// hub-to-spoke transfers.
+	ensureTunnelMSSClamp()
+
 	log.Infof("Connection Context Updated Successfully")
 
 	return &SidecarResponse{StatusMsg: "Connection Context Updated Successfully"}, nil
+}
+
+// ensureTunnelMSSClamp installs, idempotently, an iptables rule that clamps the
+// TCP MSS of forwarded connections leaving via the tunnel interface (tun0) to the
+// tunnel's path MTU. This is the standard remedy for tunnel MTU mismatches used
+// by CNIs such as Flannel and Calico (--clamp-mss-to-pmtu).
+func ensureTunnelMSSClamp() {
+	const (
+		checkCmd = "iptables -t mangle -C FORWARD -o tun0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
+		addCmd   = "iptables -t mangle -A FORWARD -o tun0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
+	)
+	if _, err := runCommand(checkCmd); err == nil {
+		return // rule already present
+	}
+	if out, err := runCommand(addCmd); err != nil {
+		log.Errorf("Failed to add TCP MSS clamp rule on tun0: %v (%v)", err, out)
+		return
+	}
+	log.Infof("Installed TCP MSS clamp (clamp-mss-to-pmtu) on tun0")
 }
 
 func (s *GwSidecar) UpdateSliceQosProfile(ctx context.Context, qosProfile *SliceQosProfile) (*SidecarResponse, error) {

--- a/pkg/sidecar/sidecarpb/gw_sidecar.go
+++ b/pkg/sidecar/sidecarpb/gw_sidecar.go
@@ -130,10 +130,16 @@ func (s *GwSidecar) UpdateConnectionContext(ctx context.Context, conContext *Sli
 	gwIP := net.ParseIP(conContext.GetRemoteSliceGwVpnIP())
 
 	route := netlink.Route{Dst: dstIPNet, Gw: gwIP}
-	log.Infof("RouteAdd args %v, %v ", dstIPNet, gwIP)
+	log.Infof("RouteReplace args %v, %v ", dstIPNet, gwIP)
 
-	if err := netlink.RouteAdd(&route); err != nil {
-		log.Errorf("Gateway Pod RouteAdd Failed : %v", err)
+	// Use RouteReplace instead of RouteAdd so this route wins over any existing
+	// route for the same destination. In a HubAndSpoke topology a spoke's gateway
+	// is asked to route the entire slice subnet via the tunnel to the hub, but NSM
+	// already installs a route for the slice subnet via the nsm interface; RouteAdd
+	// would fail with "file exists" and leave spoke-to-spoke traffic looping back to
+	// the slice router. RouteReplace is also idempotent across reconciles.
+	if err := netlink.RouteReplace(&route); err != nil {
+		log.Errorf("Gateway Pod RouteReplace Failed : %v", err)
 	}
 
 	if checkIfVppIntfPresent() {

--- a/pkg/sidecar/sidecarpb/gw_sidecar.go
+++ b/pkg/sidecar/sidecarpb/gw_sidecar.go
@@ -129,17 +129,22 @@ func (s *GwSidecar) UpdateConnectionContext(ctx context.Context, conContext *Sli
 	}
 	gwIP := net.ParseIP(conContext.GetRemoteSliceGwVpnIP())
 
-	route := netlink.Route{Dst: dstIPNet, Gw: gwIP}
-	log.Infof("RouteReplace args %v, %v ", dstIPNet, gwIP)
-
-	// Use RouteReplace instead of RouteAdd so this route wins over any existing
-	// route for the same destination. In a HubAndSpoke topology a spoke's gateway
-	// is asked to route the entire slice subnet via the tunnel to the hub, but NSM
-	// already installs a route for the slice subnet via the nsm interface; RouteAdd
-	// would fail with "file exists" and leave spoke-to-spoke traffic looping back to
-	// the slice router. RouteReplace is also idempotent across reconciles.
-	if err := netlink.RouteReplace(&route); err != nil {
-		log.Errorf("Gateway Pod RouteReplace Failed : %v", err)
+	// Program the tunnel route as two halves of the requested subnet (one bit more
+	// specific) rather than the subnet itself. NSM continuously reconciles a route
+	// for the whole slice subnet via the nsm interface using the SAME prefix we
+	// want (e.g. 10.11.0.0/16); a RouteReplace on that exact prefix only wins until
+	// NSM re-asserts, so the route FLAPS between nsm0 and tun0 and spoke-to-spoke
+	// traffic intermittently black-holes. Installing e.g. 10.11.0.0/17 + 10.11.128.0/17
+	// makes the tunnel routes strictly more specific than NSM's /16, so longest-prefix
+	// match always selects the tunnel and NSM can never overwrite them. The local
+	// subnet route (a /20 that NSM owns) stays more specific still, so local delivery
+	// is unaffected. RouteReplace keeps each write idempotent across reconciles.
+	for _, half := range moreSpecificHalves(dstIPNet) {
+		route := netlink.Route{Dst: half, Gw: gwIP}
+		log.Infof("RouteReplace args %v, %v ", half, gwIP)
+		if err := netlink.RouteReplace(&route); err != nil {
+			log.Errorf("Gateway Pod RouteReplace Failed : %v", err)
+		}
 	}
 
 	if checkIfVppIntfPresent() {
@@ -165,6 +170,28 @@ func (s *GwSidecar) UpdateConnectionContext(ctx context.Context, conContext *Sli
 	log.Infof("Connection Context Updated Successfully")
 
 	return &SidecarResponse{StatusMsg: "Connection Context Updated Successfully"}, nil
+}
+
+// moreSpecificHalves splits a subnet into its two halves, one bit more specific
+// than the input (e.g. 10.11.0.0/16 -> 10.11.0.0/17, 10.11.128.0/17). This is used
+// so the tunnel route out-specifies NSM's same-prefix route and cannot be
+// overwritten by NSM's reconcile. A host route (or a subnet that cannot be split
+// further) is returned unchanged.
+func moreSpecificHalves(dst *net.IPNet) []*net.IPNet {
+	ones, bits := dst.Mask.Size()
+	if bits == 0 || ones >= bits {
+		return []*net.IPNet{dst}
+	}
+	half := net.CIDRMask(ones+1, bits)
+	lower := dst.IP.Mask(half)
+	// upper half: set the bit at position `ones` in the network address
+	upper := make(net.IP, len(lower))
+	copy(upper, lower)
+	upper[ones/8] |= 1 << uint(7-(ones%8))
+	return []*net.IPNet{
+		{IP: lower, Mask: half},
+		{IP: upper, Mask: half},
+	}
 }
 
 // ensureTunnelMSSClamp installs, idempotently, an iptables rule that clamps the

--- a/pkg/sidecar/sidecarpb/route_split_test.go
+++ b/pkg/sidecar/sidecarpb/route_split_test.go
@@ -1,0 +1,26 @@
+package sidecar
+
+import (
+	"net"
+	"testing"
+)
+
+func TestMoreSpecificHalves(t *testing.T) {
+	cases := []struct{ in string; want []string }{
+		{"10.11.0.0/16", []string{"10.11.0.0/17", "10.11.128.0/17"}},
+		{"10.11.0.0/20", []string{"10.11.0.0/21", "10.11.8.0/21"}},
+		{"10.11.32.3/32", []string{"10.11.32.3/32"}}, // host route unchanged
+	}
+	for _, c := range cases {
+		_, n, _ := net.ParseCIDR(c.in)
+		got := moreSpecificHalves(n)
+		if len(got) != len(c.want) {
+			t.Fatalf("%s: got %d halves, want %d", c.in, len(got), len(c.want))
+		}
+		for i, g := range got {
+			if g.String() != c.want[i] {
+				t.Errorf("%s[%d]: got %s want %s", c.in, i, g.String(), c.want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Two small fixes needed for Hub-and-Spoke spoke-to-spoke traffic:

1. **RouteReplace instead of RouteAdd** — NSM already sets a route for the slice  subnet, so `RouteAdd` failed with "file exists". `RouteReplace` overwrites it so traffic actually goes into the tunnel, and is safe to re-run.

2. **Clamp TCP MSS on the tunnel** — the tunnel's usable packet size is smaller than 1500, so large packets were silently dropped (ping worked, iperf hung). Added the standard `TCPMSS --clamp-mss-to-pmtu` rule on `tun0` (and `iptables`  to the image) so packets are sized to fit.
